### PR TITLE
Add Atom/RSS feed. Resolves #3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,8 +49,5 @@ DEPENDENCIES
   jekyll-feed (~> 0.6)
   minima (~> 2.0)
 
-RUBY VERSION
-   ruby 2.2.1p85
-
 BUNDLED WITH
    1.13.6

--- a/_config.yml
+++ b/_config.yml
@@ -8,8 +8,6 @@ url: "http://docnow.io"
 
 # Build settings
 markdown: kramdown
-gems:
-  - jekyll-feed
 exclude:
   - Gemfile
   - Gemfile.lock

--- a/_data/datasets.yml
+++ b/_data/datasets.yml
@@ -1,7 +1,26 @@
+# To add your dataset copy and uncomment this item and replace the boilerplate
+# text with a description of your dataset.
+#
+# - title: My Tweet Dataset             (the title for the dataset)
+#   creator: Jack Dorsey                (creator of the dataset)
+#   url: http://example.com/my-dataset/ (web location of your dataset)
+#   published: 2014-06-08               (date when the dataset was published)
+#   added: 2016-12-24T10:14:07Z         (the current GMT time)
+#   tweets: "1,000,001"                 (number of tweets in the dataset)
+#   dates: 2009-01-01 - 2009-06-01      (date coverage in the dataset)
+#   tags:                               (one or more topical tags)
+#     - politics
+#     - sociology
+#   description: >        
+#     This is a free text description of the dataset. You can add details
+#     about how it was created and for what purpose. Add as much detail as 
+#     you want. 
+
 - title: "Yes All Women Twitter Dataset"
   creator: Mark Phillips
-  published: 2014-06-08
   url: http://digital.library.unt.edu/ark:/67531/metadc304853/
+  published: 2014-06-08
+  added: 2016-12-24T10:14:07-05:00
   tweets: "2,805,763"
   dates: 2014-05-25 - 2014-06-08
   tags:
@@ -18,6 +37,7 @@
   creator: Nick Ruest
   url: http://hdl.handle.net/10864/10830
   published: 2015-01-14
+  added: 2016-12-23T17:03:14-05:00
   tweets: "13,968,293"
   tags:
     - politics
@@ -27,8 +47,9 @@
 
 - title: Ferguson Tweets
   creator: Ed Summers
-  published: 2015-11-18
   url: https://archive.org/details/ferguson-tweet-ids
+  published: 2015-11-18
+  added: 2016-12-24T10:14:07-05:00
   tweets: "28,560,078"
   tags:
     - activism
@@ -54,29 +75,8 @@
   creator: Nick Ruest
   url: http://hdl.handle.net/10864/11270
   published: 2015-11-19
+  added: 2016-12-24T10:14:07-05:00
   tweets: "3,039,804"
-  tags:
-    - politics
-  description: >
-    Tweet ids for #elxn42 tweets.
-
-- title: "#elxn42 tweets (42nd Canadian Federal Election)"
-  creator: Library and Archives Canada
-  url: http://hdl.handle.net/10864/11270
-  published: 2015-12-04
-  tweets: "3,397,626"
-  tags:
-    - politics
-  description: >
-    Tweet ids for #elxn42 tweets.
-
-- title: "#elxn42 tweets (42nd Canadian Federal Election)"
-  creator: 
-    - Nick Ruest
-    - Library and Archives Canada
-  url: http://hdl.handle.net/10864/11311
-  published: 2015-12-07
-  tweets: "3,918,932"
   tags:
     - politics
   description: >
@@ -86,6 +86,7 @@
   creator: Nick Ruest
   url: http://hdl.handle.net/10864/11312
   published: 2015-12-12
+  added: 2016-12-23T17:40:17-05:00
   tweets: "14,939,154"
   tags:
     - politics
@@ -96,6 +97,7 @@
   creator: Library and Archives Canada
   url: http://hdl.handle.net/10864/11348
   published: 2016-01-18
+  added: 2016-12-23T10:23:06-05:00
   tweets: "2,607,886"
   tags:
     - politics
@@ -108,6 +110,7 @@
   creator: Nick Ruest
   url: http://hdl.handle.net/10864/11491
   published: 2016-03-03 
+  added: 2016-12-23T17:40:17-05:00
   tweets: "1,828,643"
   tags:
     - politics
@@ -118,6 +121,7 @@
   creator: Nick Ruest
   url: http://hdl.handle.net/10864/11591
   published: 2016-04-13
+  added: 2016-12-23T17:40:17-05:00
   tweets: "115,524"
   tags:
     - politics
@@ -128,6 +132,7 @@
   creator: "Nick Ruest"
   url: http://hdl.handle.net/10864/11592
   published: 2016-04-13
+  added: 2016-12-23T17:40:17-05:00
   tweets: "4,976,094"
   tags:
     - politics
@@ -138,6 +143,7 @@
   creator: Nick Ruest
   url: http://hdl.handle.net/10864/11674
   published: 2016-04-27 
+  added: 2016-12-23T17:40:17-05:00
   tweets: "40,279"
   tags:
     - politics
@@ -148,6 +154,7 @@
   creator: Microsoft
   url: https://www.microsoft.com/en-us/download/details.aspx?id=52598
   published: 2016-05-12
+  added: 2016-12-23T17:03:14-05:00
   tweets: "38,000,000"
   dates: 2012-07-01 - 2012-11-07
   tags:
@@ -165,6 +172,7 @@
   creator: Nick Ruest
   url: http://hdl.handle.net/10864/12033
   published: 2016-08-21
+  added: 2016-12-23T17:40:17-05:00
   tweets: "782,495"
   dates: 2016-05-01 - 2016-06-25 
   tags:
@@ -182,6 +190,7 @@
     - Daniel Kerchner
   url: http://hdl.handle.net/10.7910/DVN/PDI7IN
   published: 2016-11-29
+  added: 2016-12-23T17:03:14-05:00
   tags:
     - politics
   dates: 2016-07-13 - 2016-11-10
@@ -197,6 +206,7 @@
 - title: "The fall of Aleppo tweets; #aleppo 2016-12-13 through 2016-12-29"
   creator: Nick Ruest
   published: 2016-12-29
+  added: 2016-12-30T01:36:05-05:00
   url: http://dx.doi.org/10.5683/SP/DJLHSB
   tweets: "6,8724,29"
   dates: 2016-12-13 - 2016-12-29
@@ -208,5 +218,3 @@
     December 2015. Tweets can be "rehydrated" with Documenting the Now's twarc
     (https://github.com/DocNow/twarc). twarc.py --hydrate aleppo_tweet_ids.txt >
     aleppo.json
-
-

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,4 +4,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{ site.title }}</title>
     <link rel="stylesheet" href="{{ site.baseurl }}/css/style.css" >
+    <link rel="alternate" type="application/rss+xml" href="{{ site.url }}{{ site.baseurl }}/feed.xml" />
+
   </head>

--- a/feed.xml
+++ b/feed.xml
@@ -8,7 +8,7 @@ layout: null
     <description>{{ site.description | xml_escape }}</description>
     <link>{{ site.url }}{{ site.baseurl }}/</link>
     <atom:link href="{{ site.url }}{{ site.baseurl }}{{ page.url }}" rel="self" type="application/rss+xml" />
-    {% assign sorted_datasets = (site.data.datasets | sort: 'published' | reverse) %}
+    {% assign sorted_datasets = (site.data.datasets | sort: 'added' | reverse) %}
     {% for dataset in sorted_datasets limit:10 %}
       <item>
         <title>{{ dataset.title | xml_escape }}</title>
@@ -18,8 +18,8 @@ layout: null
         {% if dataset.description %}
           <description>{{ dataset.description | xml_escape }}</description>
         {% endif %}
-        {% if dataset.publication %}
-          <pubDate>{{ dataset.publication | date_to_rfc822 }}</pubDate>
+        {% if dataset.added %}
+          <pubDate>{{ dataset.added | date_to_rfc822 }}</pubDate>
           {% endif %}  
         <link>{{ dataset.url }}</link>
       </item>

--- a/feed.xml
+++ b/feed.xml
@@ -6,8 +6,8 @@ layout: null
   <channel>
     <title>{{ site.title | xml_escape }}</title>
     <description>{{ site.description | xml_escape }}</description>
-    <link>{{ site.url }}</link>
-    <atom:link href="{{ site.url }}/{{ page.path }}" rel="self" type="application/rss+xml" />
+    <link>{{ site.url }}{{ site.baseurl }}</link>
+    <atom:link href="{{ site.url }}{{ site.baseurl }}{{ page.url }}" rel="self" type="application/rss+xml" />
     {% assign sorted_datasets = (site.data.datasets | sort: 'published' | reverse) %}
     {% for dataset in sorted_datasets limit:10 %}
       <item>

--- a/feed.xml
+++ b/feed.xml
@@ -1,0 +1,28 @@
+---
+layout: null
+---
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>{{ site.title | xml_escape }}</title>
+    <description>{{ site.description | xml_escape }}</description>
+    <link>{{ site.url }}</link>
+    <atom:link href="{{ site.url }}/{{ page.path }}" rel="self" type="application/rss+xml" />
+    {% assign sorted_datasets = (site.data.datasets | sort: 'published' | reverse) %}
+    {% for dataset in sorted_datasets limit:10 %}
+      <item>
+        <title>{{ dataset.title | xml_escape }}</title>
+        {% if dataset.creator %}
+          <dc:creator>{{ dataset.creator | xml_escape }}</dc:creator>
+        {% endif %}
+        {% if dataset.description %}
+          <description>{{ dataset.description | xml_escape }}</description>
+        {% endif %}
+        {% if dataset.publication %}
+          <pubDate>{{ dataset.publication | date_to_rfc822 }}</pubDate>
+          {% endif %}  
+        <link>{{ dataset.url }}</link>
+      </item>
+    {% endfor %}
+  </channel>
+</rss>

--- a/feed.xml
+++ b/feed.xml
@@ -6,7 +6,7 @@ layout: null
   <channel>
     <title>{{ site.title | xml_escape }}</title>
     <description>{{ site.description | xml_escape }}</description>
-    <link>{{ site.url }}{{ site.baseurl }}</link>
+    <link>{{ site.url }}{{ site.baseurl }}/</link>
     <atom:link href="{{ site.url }}{{ site.baseurl }}{{ page.url }}" rel="self" type="application/rss+xml" />
     {% assign sorted_datasets = (site.data.datasets | sort: 'published' | reverse) %}
     {% for dataset in sorted_datasets limit:10 %}


### PR DESCRIPTION
See #3 

To test:
- `git checkout issue-3`
- `bundle exec jekyll serve`
- `curl http://127.0.0.1:4000/catalog/feed.xml`
- Should produce:

```xml
<?xml version="1.0" encoding="utf-8"?>
<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/">
  <channel>
    <title>Tweet ID Catalog</title>
    <description>This is a catalog of tweet id datasets. Please add yours by  submitting a pull request on Github.
</description>
    <link>http://localhost:4000</link>
    <atom:link href="http://localhost:4000/feed.xml" rel="self" type="application/rss+xml" />
    
    
      <item>
        <title>The fall of Aleppo tweets; #aleppo 2016-12-13 through 2016-12-29</title>
        
          <dc:creator>Nick Ruest</dc:creator>
        
        
          <description>6,8724,29 tweet ids for #aleppo tweets captured during the fall of Aleppo in December 2015. Tweets can be &quot;rehydrated&quot; with Documenting the Now's twarc (https://github.com/DocNow/twarc). twarc.py --hydrate aleppo_tweet_ids.txt &gt; aleppo.json
</description>
        
          
        <link>http://dx.doi.org/10.5683/SP/DJLHSBhttp://dx.doi.org/10.5683/SP/DJLHSB</link>
        <guid isPermaLink="true">http://localhost:4000</guid>
      </item>
    
      <item>
        <title>2016 United States Presidential Election Tweet Ids</title>
        
          <dc:creator>[&quot;Justin Littman&quot;, &quot;Laura Wrubel&quot;, &quot;Daniel Kerchner&quot;]</dc:creator>
        
        
          <description>This dataset contains the tweet ids of approximately 280 million tweets related to the 2016 United States presidential election. They were collected between July 13, 2016 and November 10, 2016 from the Twitter API using Social Feed Manager. These tweet ids are broken up into 12 collections. Each collection was collected either from the GET statuses/user_timeline method of the Twitter REST API or the POST statuses/filter method of the Twitter Stream API.
</description>
        
          
        <link>http://hdl.handle.net/10.7910/DVN/PDI7INhttp://hdl.handle.net/10.7910/DVN/PDI7IN</link>
        <guid isPermaLink="true">http://localhost:4000</guid>
      </item>
    
      <item>
        <title>#YMMfire tweets</title>
        
          <dc:creator>Nick Ruest</dc:creator>
        
        
          <description>Tweet ids for #YMMfire tweets captured during the 2016 Fort McMurray Wildfire from 2016-05-01 to 2016-06-25.
</description>
        
          
        <link>http://hdl.handle.net/10864/12033http://hdl.handle.net/10864/12033</link>
        <guid isPermaLink="true">http://localhost:4000</guid>
      </item>
    
      <item>
        <title>Election 2012 Tweet ID dataset</title>
        
          <dc:creator>Microsoft</dc:creator>
        
        
          <description>This data set identifies 38M tweets collected for the analysis of social media messages related to the 2012 U.S. Presidential election. The data set provides tweet IDs for tweets containing the words &quot;obama&quot;, &quot;romney&quot;, or both (case-insensitive matching) during the period from July 1, 2012 through November 7, 2012. The paper, “Online and Social Media Data As an Imperfect Continuous Panel Survey.” PLoS ONE 11(1): e0145406 by Diaz et al.  provides further description of the dataset.
</description>
        
          
        <link>https://www.microsoft.com/en-us/download/details.aspx?id=52598https://www.microsoft.com/en-us/download/details.aspx?id=52598</link>
        <guid isPermaLink="true">http://localhost:4000</guid>
      </item>
    
      <item>
        <title>#NDP2016 tweets</title>
        
          <dc:creator>Nick Ruest</dc:creator>
        
        
          <description>Tweet ids for #NDP2016 tweets during the 2016 NDP Convention.
</description>
        
          
        <link>http://hdl.handle.net/10864/11674http://hdl.handle.net/10864/11674</link>
        <guid isPermaLink="true">http://localhost:4000</guid>
      </item>
    
      <item>
        <title>#panamapapers tweets</title>
        
          <dc:creator>Nick Ruest</dc:creator>
        
        
          <description>Tweet ids for #panamapapers tweets.
</description>
        
          
        <link>http://hdl.handle.net/10864/11592http://hdl.handle.net/10864/11592</link>
        <guid isPermaLink="true">http://localhost:4000</guid>
      </item>
    
      <item>
        <title>#thechalkening tweets</title>
        
          <dc:creator>Nick Ruest</dc:creator>
        
        
          <description>Tweet ids for #thechalkening tweets.
</description>
        
          
        <link>http://hdl.handle.net/10864/11591http://hdl.handle.net/10864/11591</link>
        <guid isPermaLink="true">http://localhost:4000</guid>
      </item>
    
      <item>
        <title>#MakeDonaldDrumpfAgain tweets</title>
        
          <dc:creator>Nick Ruest</dc:creator>
        
        
          <description>Tweet ids for #MakeDonaldDrumpfAgain tweets.
</description>
        
          
        <link>http://hdl.handle.net/10864/11491http://hdl.handle.net/10864/11491</link>
        <guid isPermaLink="true">http://localhost:4000</guid>
      </item>
    
      <item>
        <title>#cdnpoli tweets (Canadian Politics, 2015)</title>
        
          <dc:creator>Library and Archives Canada</dc:creator>
        
        
          <description>Tweet IDs for tweets carrying the #cdnpoli hashtag, applied to Canadian politics, collected as part of a larger project centered on Canada's 42nd federal election.
</description>
        
          
        <link>http://hdl.handle.net/10864/11348http://hdl.handle.net/10864/11348</link>
        <guid isPermaLink="true">http://localhost:4000</guid>
      </item>
    
      <item>
        <title>#paris #Bataclan #parisattacks #porteouverte tweets</title>
        
          <dc:creator>Nick Ruest</dc:creator>
        
        
          <description>Tweet ids for #paris #Bataclan #parisattacks #porteouverte tweets.
</description>
        
          
        <link>http://hdl.handle.net/10864/11312http://hdl.handle.net/10864/11312</link>
        <guid isPermaLink="true">http://localhost:4000</guid>
      </item>
    
  </channel>
</rss>
```