### PR TITLE
Added AHA 2017 Tweet IDs

### DIFF
--- a/_data/datasets.yml
+++ b/_data/datasets.yml
@@ -295,7 +295,7 @@
 
 - title: American Historical Association 2017 Conference Tweets
   creator: Ian Milligan
-  url: http://dx.doi.org/10.7939/DVN/10971
+  url: http://dx.doi.org/10.5683/SP/CFVF1F
   published: 2017-01-09
   added: 2017-01-09T07:05:07Z
   tweets: "10,538"

--- a/_data/datasets.yml
+++ b/_data/datasets.yml
@@ -292,3 +292,21 @@
     have given public and Catholic school boards the right to refuse student 
     requests to form gay-straight alliances in schools. Under intense public 
     interest it was withdrawn by the Conservative government.
+
+- title: American Historical Association 2017 Conference Tweets
+  creator: Ian Milligan
+  url: http://dx.doi.org/10.7939/DVN/10971
+  published: 2017-01-09
+  added: 2017-01-09T07:05:07Z
+  tweets: "10,538"
+  dates: 2017-01-04 - 2017-01-09
+  tags:
+    - history
+    - academia
+    - conference
+  description: >
+    A list of 10,538 Twitter IDs for tweets harvested between 
+    4 January at 11am and 9 January at 11am using Social Feed 
+    Manager. As this used the search API, the 4 January at 11am 
+    crawl went back about 5-9 days. Tweet IDs included, as is a 
+    log of the decisions made to curate this dataset.


### PR DESCRIPTION
A common digital humanities use of tweets seems to be analyzing them after conferences. Here's a bunch of #AHA17 tweets collecting using Social Feed Manager.