### PR TITLE
Add North Carolina HB2 dataset

### DIFF
--- a/_data/datasets.yml
+++ b/_data/datasets.yml
@@ -310,3 +310,36 @@
     Manager. As this used the search API, the 4 January at 11am 
     crawl went back about 5-9 days. Tweet IDs included, as is a 
     log of the decisions made to curate this dataset.
+
+- title: North Carolina House Bill 2 Tweet IDs
+  creator:
+    - Jason Casden
+    - Brian Dietz
+  url: https://github.com/NCSU-Libraries/HB2-Twitter-data
+  published: 2017-01-12
+  added: 2017-01-12T12:00:00Z
+  tweets: "641,738"
+  dates: 2016-03-14 - 2017-01-12
+  tags:
+    - LGBT
+    - HB2
+    - North Carolina
+    - legal
+    - government
+    - politics
+  description: >
+    An ongoing collection of Tweets collected by NCSU Libraries using
+    twarc for the key terms "HB2", "WeAreNotThis", and "BoycottNC",
+    "KeepNCFair", and "ThisIsNotUs". "WeAreNotThis", "BoycottNC",
+    "ThisIsNotUs", and "North Carolina" beginning on 2016-03-24, and
+    "HB2" beginning on 2016-12-25. Only Tweets including "HB2", "bathroom",
+    "bill", or "KeepNCFair" are included from the "North Carolina" set.
+    These tags were used to discuss North Carolina House Bill 2
+    (The Public Facilities Privacy & Security Act), passed in March 2016,
+    which includes provisions (among others) that disallow local municipalities
+    from passing their own anti-discrimination ordinances and also require
+    individuals, when using use public bathrooms, to use those that align
+    with their sex as stated on their birth certificates rather than the
+    restroom that is consistent with their gender identity
+    (see: https://en.wikipedia.org/wiki/Public_Facilities_Privacy_%26_Security_Act).
+    This dataset is broken into files of no more than 50,000 Tweet IDs each.


### PR DESCRIPTION
A [dataset](https://github.com/NCSU-Libraries/HB2-Twitter-data) of Tweet IDs related to North Carolina's House Bill 2. The dataset construction is described in the record, and the [processing script](https://gist.github.com/cazzerson/b6f4521c2d0e8782dca06d1ae6bc7160) has been shared publicly.