### PR TITLE
adding #EstamosporTI to datasets.yml

### DIFF
--- a/_data/datasets.yml
+++ b/_data/datasets.yml
@@ -16,6 +16,24 @@
 #     This is a free text description of the dataset. You can add details
 #     about how it was created and for what purpose. Add as much detail as
 #     you want.
+- title: "#EstamosporTI"
+  creator: "Renato Gabriele"
+  url: https://archive.org/embed/EstamosporTIOohmm2018032618831Ids
+  published: 2018-03-26
+  added: 2018-03-26T15:57:00Z
+  tweets: "18,831"
+  dates: 2017-10-01 - 2017-10-24
+  tags:
+    - Catalunya
+    - Spain
+    - Comprop
+    - Oohmm
+  description: >
+    #EstamosporTI: A state-sponsored hashtag.
+    Spain’s Ministry of the Interior and security forces promoted a hashtag during the referendum shutdown & police repression in Catalunya.
+    More details and visualizations are available reading the Erin Gallagher's Medium post (https://goo.gl/ADWJ1Q) about the #EstamosporTI state sponsored hashtag.
+    The attached data set is a collection of 18,831 Tweet IDs using the #EstamosporTI hashtag covering some more days. First on Oct 1 12:07:02 UTC 2017, last on Oct 24 05:37:24 UTC 2017.
+    The attached Twitter IDs is part of a collection covering Catalan's events and elections since July 2017 (src: @remagio @Oohmminfo).
 - title: "#twitterandnews"             
   creator: Bergis Jules                
   url: https://dash.ucr.edu/stash/dataset/doi:10.6086/D1337P 


### PR DESCRIPTION
#EstamosporTI: A state-sponsored hashtag, Spain’s Ministry of the Interior and security forces promoted a hashtag during the referendum shutdown & police repression in Catalunya.
This collection cover 24 days, extending the data set used by Erin Gallagher and explained at https://goo.gl/ADWJ1Q.