### PR TITLE
Adding Macerata Attack 2018

### DIFF
--- a/_data/datasets.yml
+++ b/_data/datasets.yml
@@ -16,6 +16,29 @@
 #     This is a free text description of the dataset. You can add details
 #     about how it was created and for what purpose. Add as much detail as
 #     you want.
+- title: "Macerata Attack 2018"
+  creator: "Renato Gabriele"
+  url: https://archive.org/details/MacerataOohmm20180327574925Ids
+  published: 2018-03-27
+  added: 2018-03-27T13:25:00Z
+  tweets: "574,925"
+  dates: 2018-01-24 - 2017-02-19
+  tags:
+    - Italy
+     - Macerata
+    - Election
+     - Election 2018
+    - Comprop
+    - Racism
+    - Immigrant
+    - Terrorism
+    - Oohmm
+  description: >
+    During the last political campaign in the Italian Election 2018 populism, racism and far-right acts raised, gaining attentions by international media.
+    On February 3, a drive-by shooting targeted sub-Saharan Africans in Macerata, in central Italy, wounding at least 6 immigrants. Police charged the shooter of aggravated assault by the purpose of racism.
+    The data set give a glimpse of debates, hate speeches, protests, unofficial and official marches. Including the national march held on Feb 10 in Macerata.
+    The attached data set contains all conversations related with "Macerata"  and the shooter's name, collected since January 24, 2018 until February 19, 2018 (574,925 tweets by 116,586 users).
+    More info at Oohmm (src: @remagio @Oohmminfo https://oohmm.info/about).
 - title: "#EstamosporTI"
   creator: "Renato Gabriele"
   url: https://archive.org/details/EstamosporTIOohmm2018032618831Ids


### PR DESCRIPTION
During the last political campaign in the Italian Election 2018 populism, racism and far-right acts raised, gaining attentions by international media: On February 3, a drive-by shooting targeted sub-Saharan Africans in Macerata, in central Italy, wounding at least 6 immigrants. Police charged the shooter of aggravated assault by the purpose of racism.
The data set give a glimpse of debates, hate speeches, protests, unofficial and official marches. Including the national march held on Feb 10 in Macerata.